### PR TITLE
Pequenas sugestões ao código de conduta

### DIFF
--- a/CODIGO-DE-CONDUTA.md
+++ b/CODIGO-DE-CONDUTA.md
@@ -1,12 +1,16 @@
 # Código de Conduta
 
-Nós, os organizadores do **NodeSchool Campinas**, estamos dedicados a fornecer uma comunidade livre de abuso para todos, independente de sexo, identidade ou expressão de gênero, orientação sexual, inabilidade, aparencia e características fisicas, idade, etnia, nacionalidade, condição social ou crenças religiosas. Nós não toleramos abuso de membros da comunidade de nenhuma forma. Os participantes que violarem qualquer uma destas regras podem ser sancionados ou removidos da comunidade, a critério dos organizadores do **NodeSchool Campinas**.
+Nós, do **NodeSchool Campinas**, estamos dedicados a fornecer uma comunidade livre de abuso para todos, independente de seu sexo biológico, identidade ou expressão de gênero, orientação sexual, habilidades ou inabilidades, aparência e características físicas, idade, etnia, nacionalidade, condição social ou crenças religiosas. Não toleramos abuso por parte de membros da comunidade de nenhuma forma. Os participantes que violarem qualquer uma destas regras podem ser sancionados ou removidos da comunidade, a critério da organização do **NodeSchool Campinas**.
 
-Abuso inclui comentários ofensivos de forma verbal ou escrita relacionados a sexo, identidade ou expressão de gênero, orientação sexual, inabilidade, aparência física, idade, tamanho do corpo, raça, nacionalidade, ou crenças religiosas, intimidação, ameaças, perseguição, fotografias ou gravações abusivas, interrupção insistente de palestras ou outros eventos, contato físico inapropriado, e atenção sexual indesejada. Linguagem, expressões corporais e imagens sexuais não são apropriadas em nenhum evento organizado pela **NodeSchool Campinas** ou em qualquer canal de comunicação relacionado. Membros que praticarem quaisquer atos que constituam abuso serão advertidos, em caso de persistência e/ou reincidência, estarão sujeitos às medidas cabíveis.
+Abusos incluem intimidação, ameaças, perseguição, fotografias ou gravações abusivas, interrupção insistente de palestras ou outros eventos, contato físico inapropriado, atenção sexual indesejada descriminação e/ou comentários ofensivos verbais ou escritos relacionados ao sexo biológico, identidade ou expressão de gênero, orientação sexual, habilidades ou inabilidades, aparência e características físicas, idade, etnia, nacionalidade e crenças religiosas.
+
+Linguagem, expressões corporais e imagens de conteúdo sexuais não são apropriadas em nenhum evento organizado pela **NodeSchool Campinas** ou em qualquer canal de comunicação relacionado. Membros que praticarem quaisquer atos que constituam abuso serão advertidos, em caso de persistência e/ou reincidência, estarão sujeitos às medidas cabíveis.
 
 > **Organizadores, patrocinadores, expositores, participantes e quaisquer outros envolvidos com a comunidade devem respeitar esse código de conduta.**
 
-Se um membro da comunidade praticar, ainda que indiretamente, comportamento abusivo, os organizadores da **NodeSchool Campinas** podem tomar quaisquer ações que julgarem apropriadas, incluindo advertir o ofensor ou expulsá-lo da comunidade. Se você sofrer abuso, perceber que alguém está sofrendo abuso, ou tiver qualquer tipo de suspeita, por favor contate um organizador imediatamente.
+Membros da comunidade que praticarem, ainda que indiretamente, ou incentivarem a prática de qualquer comportamento abusivo estarão sujeitos ao julgamento por parte da organização da **NodeSchool Campinas**, que podem tomar quaisquer ações que julgarem apropriadas, incluindo advertir o ofensor ou expulsá-lo da comunidade. 
+
+**Se você sofrer abuso, perceber que alguém está sofrendo abuso, ou tiver qualquer tipo de suspeita, por favor contate um organizador imediatamente.**
 
 ## **Política de desistência**
 Se por algum motivo o participante confirmar presença e faltar sem cancelar o RSVP em até 48h antes (ou sem justificativa plausível), estará sujeito as seguintes punições:
@@ -15,7 +19,7 @@ Se por algum motivo o participante confirmar presença e faltar sem cancelar o R
 
 ### **NodeSchool Campinas**
 
-* Organizadores:
+* Organização:
   * Veja a lista completa [neste link](README.md).
 * Links relacionados:
   * Site oficial: http://nodeschool.io/campinas
@@ -26,4 +30,4 @@ Se por algum motivo o participante confirmar presença e faltar sem cancelar o R
 
 **Se você tiver qualquer dúvida ou feedback sobre este Código de Conduta por favor contate um dos organizadores.**
 
-Os organizadores da comunidade acima desenvolveram este Código de Conduta para regulamentar os seus respectivos eventos e canais de comunicação. Nós usamos a [Política Anti-Abuso da PDX Python](http://www.meetup.com/pdxpython/pages/Code_of_Conduct/) e a [Política Anti-Abuso da Conferência Geek Feminina](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy) como um ponto de partida. Este Código de Conduta, assim como as suas inspirações, estão licenciados sobre os termos da [Licença Creative Commons Zero](http://creativecommons.org/publicdomain/zero/1.0/).
+A organização da comunidade acima desenvolveu este Código de Conduta para regulamentar os seus respectivos eventos e canais de comunicação. Nós usamos a [Política Anti-Abuso da PDX Python](http://www.meetup.com/pdxpython/pages/Code_of_Conduct/) e a [Política Anti-Abuso da Conferência Geek Feminina](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy) como um ponto de partida. Este Código de Conduta, assim como as suas inspirações, estão licenciados sobre os termos da [Licença Creative Commons Zero](http://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
Relacionado a issue #24
- Coloca organizadores e comunidade no mesmo patamar para zelar pelo código de conduta, comunidade livre de abusos deve ser um objetivo para todos e não somente organizadores
- Troca o termo Organizadores pelo termo neutro Organização para que mulheres possam idealizar organizar a escola no futuro
- Esclarece que o sexo de que se refere é o sexo biológico dos membros
- Descreve com mais objetividade os tipos de abusos e suas motivações ao inverter o parágrafo 
- Quebra parágrafo para iniciar o assunto de linguagem imprópria
- Inclui o ato de incentivar o comportamento abusivo como passível de punição
- Destaca chamada para denuncia
- Corrige acentuação em alguns pontos